### PR TITLE
fix: resolve clippy warnings and formatting issues

### DIFF
--- a/clap-mcp/src/lib.rs
+++ b/clap-mcp/src/lib.rs
@@ -11,7 +11,6 @@ use rmcp::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use std::future::Future;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -32,12 +31,18 @@ pub struct McpServer<T: Subcommand> {
     _phantom: PhantomData<T>,
 }
 
-impl<T: Subcommand + Send + Sync + Clone + 'static> McpServer<T> {
-    pub fn new() -> Self {
+impl<T: Subcommand + Send + Sync + Clone + 'static> Default for McpServer<T> {
+    fn default() -> Self {
         Self {
             handler: None,
             _phantom: PhantomData,
         }
+    }
+}
+
+impl<T: Subcommand + Send + Sync + Clone + 'static> McpServer<T> {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn with_handler(mut self, handler: CommandHandler<T>) -> Self {
@@ -147,7 +152,7 @@ impl<T: Subcommand> ClapMcpHandler<T> {
 
                 let arg_name = arg.get_id().to_string();
                 let is_positional = arg.get_long().is_none() && arg.get_short().is_none();
-                
+
                 let arg_type = if arg.get_num_args().map(|r| r.min_values()).unwrap_or(0) == 0 {
                     "boolean"
                 } else {
@@ -163,7 +168,7 @@ impl<T: Subcommand> ClapMcpHandler<T> {
                 if let Some(help) = arg.get_help() {
                     schema["description"] = json!(help.to_string());
                 }
-                
+
                 // Add metadata to indicate positional arguments
                 if is_positional {
                     schema["x-positional"] = json!(true);
@@ -217,132 +222,134 @@ impl<T: Subcommand + Send + Sync + 'static> ServerHandler for ClapMcpHandler<T> 
         }
     }
 
-    fn list_tools(
+    async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParam>,
         _context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
-        async move {
-            let tools = Self::extract_subcommands();
-            Ok(ListToolsResult {
-                tools,
-                next_cursor: None,
-            })
-        }
+    ) -> Result<ListToolsResult, McpError> {
+        let tools = Self::extract_subcommands();
+        Ok(ListToolsResult {
+            tools,
+            next_cursor: None,
+        })
     }
 
-    fn call_tool(
+    async fn call_tool(
         &self,
         request: CallToolRequestParam,
         _context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
-        async move {
-            let tool_name = request.name.to_string();
-            let arguments = request.arguments.unwrap_or_default();
+    ) -> Result<CallToolResult, McpError> {
+        let tool_name = request.name.to_string();
+        let arguments = request.arguments.unwrap_or_default();
 
-            // Get the tool definition to check which arguments are positional
-            let tools = Self::extract_subcommands();
-            let tool = tools.iter().find(|t| t.name == tool_name);
-            
-            // Build command line arguments
-            // First arg should be the program name, then the subcommand
-            let mut args = vec!["mcp".to_string(), tool_name.clone()];
+        // Get the tool definition to check which arguments are positional
+        let tools = Self::extract_subcommands();
+        let tool = tools.iter().find(|t| t.name == tool_name);
 
-            // Separate positional and named arguments
-            let mut positional_args: Vec<(String, serde_json::Value, usize)> = Vec::new();
-            let mut named_args = HashMap::new();
-            
-            for (key, value) in arguments {
-                // Check if this argument is positional by looking at the tool schema
-                let is_positional = tool.and_then(|t| {
-                    t.input_schema.get("properties")
+        // Build command line arguments
+        // First arg should be the program name, then the subcommand
+        let mut args = vec!["mcp".to_string(), tool_name.clone()];
+
+        // Separate positional and named arguments
+        let mut positional_args: Vec<(String, serde_json::Value, usize)> = Vec::new();
+        let mut named_args = HashMap::new();
+
+        for (key, value) in arguments {
+            // Check if this argument is positional by looking at the tool schema
+            let is_positional = tool
+                .and_then(|t| {
+                    t.input_schema
+                        .get("properties")
                         .and_then(|props| props.get(&key))
                         .and_then(|schema| schema.get("x-positional"))
                         .and_then(|v| v.as_bool())
-                }).unwrap_or(false);
-                
-                if is_positional {
-                    let position = tool.and_then(|t| {
-                        t.input_schema.get("properties")
+                })
+                .unwrap_or(false);
+
+            if is_positional {
+                let position =
+                    tool.and_then(|t| {
+                        t.input_schema
+                            .get("properties")
                             .and_then(|props| props.get(&key))
                             .and_then(|schema| schema.get("x-position"))
                             .and_then(|v| v.as_u64())
-                    }).unwrap_or(positional_args.len() as u64) as usize;
-                    
-                    positional_args.push((key, value, position));
-                } else {
-                    named_args.insert(key, value);
-                }
-            }
-            
-            // Sort positional arguments by their position
-            positional_args.sort_by_key(|&(_, _, pos)| pos);
-            
-            // Add positional arguments first (without -- prefix)
-            for (_, value, _) in positional_args {
-                match value {
-                    serde_json::Value::String(s) => args.push(s),
-                    serde_json::Value::Number(n) => args.push(n.to_string()),
-                    serde_json::Value::Bool(b) => args.push(b.to_string()),
-                    _ => args.push(value.to_string()),
-                }
-            }
-            
-            // Then add named arguments with -- prefix
-            for (key, value) in named_args {
-                match value {
-                    serde_json::Value::Bool(b) => {
-                        if b {
-                            args.push(format!("--{}", key));
-                        }
-                        // Skip false boolean flags
-                    }
-                    serde_json::Value::String(s) => {
-                        args.push(format!("--{}", key));
-                        args.push(s);
-                    }
-                    serde_json::Value::Number(n) => {
-                        args.push(format!("--{}", key));
-                        args.push(n.to_string());
-                    }
-                    _ => {
-                        args.push(format!("--{}", key));
-                        args.push(value.to_string());
-                    }
-                }
-            }
+                    })
+                    .unwrap_or(positional_args.len() as u64) as usize;
 
-            // Parse the arguments into a subcommand
-            let cmd = T::augment_subcommands(clap::Command::new("mcp"));
-            match cmd.try_get_matches_from(&args) {
-                Ok(matches) => {
-                    match T::from_arg_matches(&matches) {
-                        Ok(subcommand) => {
-                            // Use the handler if provided
-                            if let Some(handler) = &self.handler {
-                                match handler(subcommand) {
-                                    Ok(output) => {
-                                        Ok(CallToolResult::success(vec![Content::text(output)]))
-                                    }
-                                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e)])),
+                positional_args.push((key, value, position));
+            } else {
+                named_args.insert(key, value);
+            }
+        }
+
+        // Sort positional arguments by their position
+        positional_args.sort_by_key(|&(_, _, pos)| pos);
+
+        // Add positional arguments first (without -- prefix)
+        for (_, value, _) in positional_args {
+            match value {
+                serde_json::Value::String(s) => args.push(s),
+                serde_json::Value::Number(n) => args.push(n.to_string()),
+                serde_json::Value::Bool(b) => args.push(b.to_string()),
+                _ => args.push(value.to_string()),
+            }
+        }
+
+        // Then add named arguments with -- prefix
+        for (key, value) in named_args {
+            match value {
+                serde_json::Value::Bool(b) => {
+                    if b {
+                        args.push(format!("--{}", key));
+                    }
+                    // Skip false boolean flags
+                }
+                serde_json::Value::String(s) => {
+                    args.push(format!("--{}", key));
+                    args.push(s);
+                }
+                serde_json::Value::Number(n) => {
+                    args.push(format!("--{}", key));
+                    args.push(n.to_string());
+                }
+                _ => {
+                    args.push(format!("--{}", key));
+                    args.push(value.to_string());
+                }
+            }
+        }
+
+        // Parse the arguments into a subcommand
+        let cmd = T::augment_subcommands(clap::Command::new("mcp"));
+        match cmd.try_get_matches_from(&args) {
+            Ok(matches) => {
+                match T::from_arg_matches(&matches) {
+                    Ok(subcommand) => {
+                        // Use the handler if provided
+                        if let Some(handler) = &self.handler {
+                            match handler(subcommand) {
+                                Ok(output) => {
+                                    Ok(CallToolResult::success(vec![Content::text(output)]))
                                 }
-                            } else {
-                                Ok(CallToolResult::error(vec![Content::text(
+                                Err(e) => Ok(CallToolResult::error(vec![Content::text(e)])),
+                            }
+                        } else {
+                            Ok(CallToolResult::error(vec![Content::text(
                                     "No command handler provided. The CLI must provide a handler function to execute commands in MCP mode."
                                 )]))
-                            }
                         }
-                        Err(e) => Err(McpError::invalid_params(
-                            format!("Failed to parse subcommand: {}", e),
-                            None,
-                        )),
                     }
+                    Err(e) => Err(McpError::invalid_params(
+                        format!("Failed to parse subcommand: {}", e),
+                        None,
+                    )),
                 }
-                Err(e) => Err(McpError::invalid_params(
-                    format!("Invalid arguments: {}", e),
-                    None,
-                )),
             }
+            Err(e) => Err(McpError::invalid_params(
+                format!("Invalid arguments: {}", e),
+                None,
+            )),
         }
     }
 }
@@ -408,9 +415,15 @@ mod tests {
     fn execute_test_command(cmd: TestCommands) -> Result<String, String> {
         match cmd {
             TestCommands::Add { a, b } => Ok(format!("{} + {} = {}", a, b, a + b)),
-            TestCommands::Subtract { minuend, subtrahend } => {
-                Ok(format!("{} - {} = {}", minuend, subtrahend, minuend - subtrahend))
-            }
+            TestCommands::Subtract {
+                minuend,
+                subtrahend,
+            } => Ok(format!(
+                "{} - {} = {}",
+                minuend,
+                subtrahend,
+                minuend - subtrahend
+            )),
             TestCommands::Multiply { value1, value2 } => {
                 Ok(format!("{} * {} = {}", value1, value2, value1 * value2))
             }
@@ -418,7 +431,12 @@ mod tests {
                 if divisor == 0 {
                     Err("Division by zero".to_string())
                 } else {
-                    Ok(format!("{} ÷ {} = {}", dividend, divisor, dividend / divisor))
+                    Ok(format!(
+                        "{} ÷ {} = {}",
+                        dividend,
+                        divisor,
+                        dividend / divisor
+                    ))
                 }
             }
             TestCommands::Hello { name, excited } => {
@@ -438,20 +456,20 @@ mod tests {
         FromUtf8 {
             /// The text to convert
             text: String,
-            
+
             /// Optional second positional argument
             optional: Option<String>,
         },
-        
+
         /// Example with mixed args
         Mixed {
             /// First positional
             input: String,
-            
+
             /// A flag
             #[arg(short, long)]
             verbose: bool,
-            
+
             /// Second positional  
             output: String,
         },
@@ -460,14 +478,20 @@ mod tests {
     fn execute_positional_command(cmd: PositionalCommands) -> Result<String, String> {
         match cmd {
             PositionalCommands::FromUtf8 { text, optional } => {
-                let hex = text.chars()
+                let hex = text
+                    .chars()
                     .map(|c| format!("{:02x}", c as u8))
                     .collect::<String>();
                 Ok(format!("0x{} (optional: {:?})", hex, optional))
             }
-            PositionalCommands::Mixed { input, verbose, output } => {
-                Ok(format!("Input: {}, Output: {}, Verbose: {}", input, output, verbose))
-            }
+            PositionalCommands::Mixed {
+                input,
+                verbose,
+                output,
+            } => Ok(format!(
+                "Input: {}, Output: {}, Verbose: {}",
+                input, output, verbose
+            )),
         }
     }
 
@@ -486,7 +510,7 @@ mod tests {
         let port = get_available_port().await;
         let addr = format!("127.0.0.1:{}", port).parse()?;
         let handler = ClapMcpHandler::<T>::new(Some(handler));
-        
+
         let config = SseServerConfig {
             bind: addr,
             sse_path: "/sse".to_string(),
@@ -499,10 +523,10 @@ mod tests {
         let ct = sse_server.config.ct.clone();
 
         let listener = tokio::net::TcpListener::bind(sse_server.config.bind).await?;
-        
+
         let server_ct = ct.child_token();
-        let server = axum::serve(listener, router.into_make_service())
-            .with_graceful_shutdown(async move {
+        let server =
+            axum::serve(listener, router.into_make_service()).with_graceful_shutdown(async move {
                 server_ct.cancelled().await;
             });
 
@@ -513,7 +537,7 @@ mod tests {
         });
 
         let _service_ct = sse_server.with_service(move || handler.clone());
-        
+
         // Wait for server to be ready by attempting connection
         let addr_str = format!("127.0.0.1:{}", port);
         for _ in 0..50 {
@@ -522,29 +546,28 @@ mod tests {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
             }
         }
-        
+
         Ok((ct, port))
     }
 
     #[tokio::test]
     async fn test_calculator_mcp() {
         use crate::test_client::McpTestClient;
-        
+
         // Start server
-        let (ct, port) = start_in_process_server::<TestCommands>(
-            Box::new(execute_test_command)
-        ).await.expect("Failed to start server");
-        
-        
+        let (ct, port) = start_in_process_server::<TestCommands>(Box::new(execute_test_command))
+            .await
+            .expect("Failed to start server");
+
         // Connect to server
         let client = McpTestClient::connect(&format!("127.0.0.1:{}", port))
             .await
             .expect("Failed to connect to server");
-        
+
         // List tools
         let tools = client.list_tools().await.expect("Failed to list tools");
         assert_eq!(tools.len(), 5); // add, subtract, multiply, divide, hello
-        
+
         // Test add command
         let result = client
             .call_tool("add", Some(json!({ "a": 10, "b": 32 })))
@@ -552,7 +575,7 @@ mod tests {
             .expect("Failed to call add");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "10 + 32 = 42");
-        
+
         // Test multiply command
         let result = client
             .call_tool("multiply", Some(json!({ "value1": 7, "value2": 6 })))
@@ -560,7 +583,7 @@ mod tests {
             .expect("Failed to call multiply");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "7 * 6 = 42");
-        
+
         // Test divide command with error
         let result = client
             .call_tool("divide", Some(json!({ "dividend": 10, "divisor": 0 })))
@@ -569,7 +592,7 @@ mod tests {
         assert!(result.is_error.unwrap_or(false));
         let text = McpTestClient::extract_text(&result).expect("No text in error");
         assert!(text.contains("Division by zero"));
-        
+
         // Test hello command
         let result = client
             .call_tool("hello", Some(json!({ "name": "Test", "excited": true })))
@@ -577,7 +600,7 @@ mod tests {
             .expect("Failed to call hello");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "Hello, Test!!!");
-        
+
         // Shutdown
         client.shutdown().await.expect("Failed to shutdown client");
         ct.cancel();
@@ -586,45 +609,58 @@ mod tests {
     #[tokio::test]
     async fn test_missing_arguments() {
         use crate::test_client::McpTestClient;
-        
+
         // Start server
-        let (ct, port) = start_in_process_server::<TestCommands>(
-            Box::new(execute_test_command)
-        ).await.expect("Failed to start server");
-        
-        
+        let (ct, port) = start_in_process_server::<TestCommands>(Box::new(execute_test_command))
+            .await
+            .expect("Failed to start server");
+
         let client = McpTestClient::connect(&format!("127.0.0.1:{}", port))
             .await
             .expect("Failed to connect to server");
-        
+
         // Try calling add without any arguments - the call itself succeeds but returns an error result
         let result = client.call_tool("add", Some(json!({}))).await;
-        
+
         // The call should succeed but return an error in the result
         match result {
             Ok(call_result) => {
                 // We expect this to be an error response (missing required arguments)
-                assert!(call_result.is_error.unwrap_or(false), "Expected error for missing arguments");
+                assert!(
+                    call_result.is_error.unwrap_or(false),
+                    "Expected error for missing arguments"
+                );
             }
             Err(e) => {
                 // This is actually expected - the MCP error for invalid arguments
-                assert!(e.to_string().contains("Invalid arguments") || e.to_string().contains("required arguments"), 
-                       "Unexpected error: {}", e);
+                assert!(
+                    e.to_string().contains("Invalid arguments")
+                        || e.to_string().contains("required arguments"),
+                    "Unexpected error: {}",
+                    e
+                );
             }
         }
-        
+
         // Try calling add with only one argument
         let result = client.call_tool("add", Some(json!({ "a": 5 }))).await;
         match result {
             Ok(call_result) => {
-                assert!(call_result.is_error.unwrap_or(false), "Expected error for missing b argument");
+                assert!(
+                    call_result.is_error.unwrap_or(false),
+                    "Expected error for missing b argument"
+                );
             }
             Err(e) => {
-                assert!(e.to_string().contains("Invalid arguments") || e.to_string().contains("required arguments"), 
-                       "Unexpected error: {}", e);
+                assert!(
+                    e.to_string().contains("Invalid arguments")
+                        || e.to_string().contains("required arguments"),
+                    "Unexpected error: {}",
+                    e
+                );
             }
         }
-        
+
         // Shutdown
         client.shutdown().await.expect("Failed to shutdown client");
         ct.cancel();
@@ -633,17 +669,17 @@ mod tests {
     #[tokio::test]
     async fn test_positional_args() {
         use crate::test_client::McpTestClient;
-        
+
         // Start server
-        let (ct, port) = start_in_process_server::<PositionalCommands>(
-            Box::new(execute_positional_command)
-        ).await.expect("Failed to start server");
-        
-        
+        let (ct, port) =
+            start_in_process_server::<PositionalCommands>(Box::new(execute_positional_command))
+                .await
+                .expect("Failed to start server");
+
         let client = McpTestClient::connect(&format!("127.0.0.1:{}", port))
             .await
             .expect("Failed to connect to server");
-        
+
         // Test from-utf8 with required positional argument
         let result = client
             .call_tool("from-utf8", Some(json!({ "text": "hello" })))
@@ -651,23 +687,29 @@ mod tests {
             .expect("Failed to call from-utf8");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "0x68656c6c6f (optional: None)");
-        
+
         // Test from-utf8 with optional positional argument
         let result = client
-            .call_tool("from-utf8", Some(json!({ "text": "hello", "optional": "world" })))
+            .call_tool(
+                "from-utf8",
+                Some(json!({ "text": "hello", "optional": "world" })),
+            )
             .await
             .expect("Failed to call from-utf8");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "0x68656c6c6f (optional: Some(\"world\"))");
-        
+
         // Test mixed command with multiple positionals and flags
         let result = client
-            .call_tool("mixed", Some(json!({ "input": "foo.txt", "output": "bar.txt", "verbose": true })))
+            .call_tool(
+                "mixed",
+                Some(json!({ "input": "foo.txt", "output": "bar.txt", "verbose": true })),
+            )
             .await
             .expect("Failed to call mixed");
         let text = McpTestClient::extract_text(&result).expect("No text in result");
         assert_eq!(text, "Input: foo.txt, Output: bar.txt, Verbose: true");
-        
+
         // Shutdown
         client.shutdown().await.expect("Failed to shutdown client");
         ct.cancel();
@@ -676,33 +718,51 @@ mod tests {
     #[tokio::test]
     async fn test_http_client_operations() {
         use crate::test_client::McpTestClient;
-        
+
         // Start server
-        let (ct, port) = start_in_process_server::<TestCommands>(
-            Box::new(execute_test_command)
-        ).await.expect("Failed to start server");
-        
-        
+        let (ct, port) = start_in_process_server::<TestCommands>(Box::new(execute_test_command))
+            .await
+            .expect("Failed to start server");
+
         let client = McpTestClient::connect(&format!("127.0.0.1:{}", port))
             .await
             .expect("Failed to connect to server");
-        
+
         // List tools and verify count
         let tools = client.list_tools().await.expect("Failed to list tools");
         assert_eq!(tools.len(), 5); // add, subtract, multiply, divide, hello
-        
+
         // Verify tool metadata
-        let add_tool = tools.iter().find(|t| t.name == "add").expect("Add tool not found");
-        assert!(add_tool.description.as_ref().unwrap().contains("Add two numbers"));
-        
+        let add_tool = tools
+            .iter()
+            .find(|t| t.name == "add")
+            .expect("Add tool not found");
+        assert!(add_tool
+            .description
+            .as_ref()
+            .unwrap()
+            .contains("Add two numbers"));
+
         // Test a sequence of operations
         let operations = vec![
             ("add", json!({ "a": 100, "b": 200 }), "100 + 200 = 300"),
-            ("subtract", json!({ "minuend": 50, "subtrahend": 20 }), "50 - 20 = 30"),
-            ("multiply", json!({ "value1": 11, "value2": 11 }), "11 * 11 = 121"),
-            ("divide", json!({ "dividend": 100, "divisor": 4 }), "100 ÷ 4 = 25"),
+            (
+                "subtract",
+                json!({ "minuend": 50, "subtrahend": 20 }),
+                "50 - 20 = 30",
+            ),
+            (
+                "multiply",
+                json!({ "value1": 11, "value2": 11 }),
+                "11 * 11 = 121",
+            ),
+            (
+                "divide",
+                json!({ "dividend": 100, "divisor": 4 }),
+                "100 ÷ 4 = 25",
+            ),
         ];
-        
+
         for (op, args, expected) in operations {
             let result = client
                 .call_tool(op, Some(args))
@@ -712,7 +772,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("No text in {} result", op));
             assert_eq!(text, expected);
         }
-        
+
         // Shutdown
         client.shutdown().await.expect("Failed to shutdown client");
         ct.cancel();

--- a/clap-mcp/src/test_client.rs
+++ b/clap-mcp/src/test_client.rs
@@ -1,6 +1,6 @@
 //! Test utilities for clap-mcp
 
-use rmcp::{model::*, transport::SseClientTransport, ServiceExt, RoleClient};
+use rmcp::{model::*, transport::SseClientTransport, RoleClient, ServiceExt};
 use serde_json::Value;
 
 /// An MCP test client for testing MCP servers
@@ -13,7 +13,7 @@ impl McpTestClient {
     pub async fn connect(addr: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let sse_url = format!("http://{}/sse", addr);
         let transport = SseClientTransport::start(sse_url).await?;
-        
+
         let client_info = ClientInfo {
             protocol_version: ProtocolVersion::V_2024_11_05,
             capabilities: ClientCapabilities::default(),
@@ -22,18 +22,18 @@ impl McpTestClient {
                 version: "1.0".to_string(),
             },
         };
-        
+
         let client = client_info.serve(transport).await?;
-        
+
         Ok(Self { client })
     }
-    
+
     /// List all available tools
     pub async fn list_tools(&self) -> Result<Vec<Tool>, Box<dyn std::error::Error>> {
         let result = self.client.list_tools(None).await?;
         Ok(result.tools)
     }
-    
+
     /// Call a tool with optional arguments
     pub async fn call_tool(
         &self,
@@ -41,7 +41,8 @@ impl McpTestClient {
         arguments: Option<Value>,
     ) -> Result<CallToolResult, Box<dyn std::error::Error>> {
         let args = arguments.and_then(|v| v.as_object().cloned());
-        let result = self.client
+        let result = self
+            .client
             .call_tool(CallToolRequestParam {
                 name: name.to_string().into(),
                 arguments: args,
@@ -49,7 +50,7 @@ impl McpTestClient {
             .await?;
         Ok(result)
     }
-    
+
     /// Extract text content from a tool result
     pub fn extract_text(result: &CallToolResult) -> Option<String> {
         result.content.first().and_then(|content| {
@@ -60,7 +61,7 @@ impl McpTestClient {
             }
         })
     }
-    
+
     /// Shutdown the client
     pub async fn shutdown(self) -> Result<(), Box<dyn std::error::Error>> {
         self.client.cancel().await?;
@@ -72,24 +73,21 @@ impl McpTestClient {
 pub mod test_utils {
     use std::process::{Child, Command, Stdio};
     use std::time::Duration;
-    
+
     /// Start a server process for testing
-    pub fn start_test_server(
-        exe_path: &str,
-        args: &[&str],
-    ) -> std::io::Result<Child> {
+    pub fn start_test_server(exe_path: &str, args: &[&str]) -> std::io::Result<Child> {
         Command::new(exe_path)
             .args(args)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
     }
-    
+
     /// Wait for a server to be ready
     pub async fn wait_for_server(addr: &str, timeout_secs: u64) -> bool {
         let start = std::time::Instant::now();
         let timeout = Duration::from_secs(timeout_secs);
-        
+
         while start.elapsed() < timeout {
             if let Ok(client) = super::McpTestClient::connect(addr).await {
                 let _ = client.shutdown().await;

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -70,13 +70,13 @@ enum Commands {
         #[arg(short, long, default_value = "false")]
         excited: bool,
     },
-    
+
     /// Square a number (positional argument example)
     Square {
         /// The number to square
         number: f64,
     },
-    
+
     /// Echo text with optional suffix (mixed positional and named args)
     Echo {
         /// Text to echo
@@ -115,10 +115,12 @@ fn execute_command(cmd: Commands) -> Result<String, String> {
                 Ok(format!("Hello, {}.", name))
             }
         }
-        Commands::Square { number } => {
-            Ok(format!("{} squared is {}", number, number * number))
-        }
-        Commands::Echo { text, suffix, uppercase } => {
+        Commands::Square { number } => Ok(format!("{} squared is {}", number, number * number)),
+        Commands::Echo {
+            text,
+            suffix,
+            uppercase,
+        } => {
             let mut result = text.clone();
             if let Some(suf) = suffix {
                 result.push(' ');

--- a/examples/http_mcp_client.rs
+++ b/examples/http_mcp_client.rs
@@ -7,14 +7,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
 
     println!("Connecting to MCP server at http://127.0.0.1:8080...");
-    
+
     // Connect to server
     let client = McpTestClient::connect("127.0.0.1:8080").await?;
 
@@ -83,10 +82,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if result.is_error.unwrap_or(false) {
         println!("Error in result");
-    } else {
-        if let Some(text) = McpTestClient::extract_text(&result) {
-            println!("Result: {}", text);
-        }
+    } else if let Some(text) = McpTestClient::extract_text(&result) {
+        println!("Result: {}", text);
     }
 
     // Call multiply
@@ -97,24 +94,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if result.is_error.unwrap_or(false) {
         println!("Error in result");
-    } else {
-        if let Some(text) = McpTestClient::extract_text(&result) {
-            println!("Result: {}", text);
-        }
+    } else if let Some(text) = McpTestClient::extract_text(&result) {
+        println!("Result: {}", text);
     }
 
     // Call hello
     println!("\n=== Testing hello(MCP User, excited=true) ===");
     let result = client
-        .call_tool("hello", Some(json!({ "name": "MCP User", "excited": true })))
+        .call_tool(
+            "hello",
+            Some(json!({ "name": "MCP User", "excited": true })),
+        )
         .await?;
 
     if result.is_error.unwrap_or(false) {
         println!("Error in result");
-    } else {
-        if let Some(text) = McpTestClient::extract_text(&result) {
-            println!("Result: {}", text);
-        }
+    } else if let Some(text) = McpTestClient::extract_text(&result) {
+        println!("Result: {}", text);
     }
 
     println!("\nAll tests complete!");


### PR DESCRIPTION
Fixed several CI errors:
- Replaced single-match patterns with if-let in derive macro
- Added Default implementation for McpServer<T>
- Converted manual async functions to async fn syntax
- Removed unused Future import
- Fixed indentation issues in async function bodies
- Collapsed else-if blocks in http_mcp_client example

All CI checks now pass: formatting (cargo +nightly fmt), clippy linting, builds, and tests.

🤖 Generated with [Claude Code](https://claude.ai/code)